### PR TITLE
Nissix plugin scope-packages on surge-github-autorelease

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sinon": "^5.0.7",
     "sinon-chai": "^3.0.0",
     "typescript": "^4.1.3",
-    "yoshi": "^3.31.6"
+    "@wix/yoshi": "^3.31.6"
   },
   "dependencies": {
     "@octokit/rest": "^15.4.0",

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 5.732s



Output Log:
Migrating package "surge-github-autorelease" in .


## Migration from non scope to @wix/scoped packages
> /tmp/26278679e2dd9de8337b6fc012c21e41

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
```

